### PR TITLE
handle GSM network errors by default (+CMS ERROR:)

### DIFF
--- a/components/le_pa/pa_utils_local.h
+++ b/components/le_pa/pa_utils_local.h
@@ -44,7 +44,7 @@
  * Default Expected AT Command Response.
  */
 //--------------------------------------------------------------------------------------------------
-#define DEFAULT_AT_RESPONSE             "OK|ERROR|+CME ERROR:"
+#define DEFAULT_AT_RESPONSE             "OK|ERROR|+CME ERROR:|+CMS ERROR"
 
 //--------------------------------------------------------------------------------------------------
 /**


### PR DESCRIPTION
while testing with a gsm module that was not booked into a network, the modemService was blocked on startup as +CMS errors were not handled.
adding +CMS ERROR: to the patterns of possible return values fixes this.